### PR TITLE
Upgrade `read-pkg` to v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const findUp = require('find-up');
 const readPkg = require('read-pkg');
 
@@ -8,7 +9,8 @@ module.exports = options => {
 			return {};
 		}
 
-		return readPkg(fp, options).then(pkg => ({pkg, path: fp}));
+		return readPkg({...options, cwd: path.dirname(fp)})
+			.then(pkg => ({pkg, path: fp}));
 	});
 };
 
@@ -20,7 +22,7 @@ module.exports.sync = options => {
 	}
 
 	return {
-		pkg: readPkg.sync(fp, options),
+		pkg: readPkg.sync({...options, cwd: path.dirname(fp)}),
 		path: fp
 	};
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = options => {
 			return {};
 		}
 
-		return readPkg({...options, cwd: path.dirname(fp)})
+		return readPkg(Object.assign({}, options, {cwd: path.dirname(fp)}))
 			.then(pkg => ({pkg, path: fp}));
 	});
 };
@@ -22,7 +22,7 @@ module.exports.sync = options => {
 	}
 
 	return {
-		pkg: readPkg.sync({...options, cwd: path.dirname(fp)}),
+		pkg: readPkg.sync(Object.assign({}, options, {cwd: path.dirname(fp)})),
 		path: fp
 	};
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	],
 	"dependencies": {
 		"find-up": "^3.0.0",
-		"read-pkg": "^3.0.0"
+		"read-pkg": "^4.0.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/test.js
+++ b/test.js
@@ -9,10 +9,18 @@ test('async', async t => {
 	const x = await m({cwd});
 	t.is(x.pkg.name, 'read-pkg-up');
 	t.is(x.path, pkgPath);
+
+	const y = await m({cwd: '/'});
+	t.is(y.pkg, undefined);
+	t.is(y.path, undefined);
 });
 
 test('sync', t => {
 	const x = m.sync({cwd});
 	t.is(x.pkg.name, 'read-pkg-up');
 	t.is(x.path, pkgPath);
+
+	const y = m.sync({cwd: '/'});
+	t.is(y.pkg, undefined);
+	t.is(y.path, undefined);
 });


### PR DESCRIPTION
This is just to get the new typings needed for #6. It would be good to wait until the typings are actually added to that before merging so that we can define use what ends up being the actual version number of that package.

I also added a couple small tests.