### PR TITLE
fix: the package needs nodejs >= 16 to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": ">=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
Since we have  

```javascript
import path from 'node:path'
```
and the CI run only on node 16
read-pkg-up do not run on node 14 (still LTS) and give the following error message:

```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /node_modules/read-pkg-up/index.js
```

So either update the code and the CI to guarantie it runs on LTS or remove this from the package.json.

I propose here with this PR to remove it from the package.json

![Screenshot 2022-03-11 at 16 00 10](https://user-images.githubusercontent.com/19857479/157892400-bb89be89-a5a9-409a-888d-83a33ad4ac6b.png)
